### PR TITLE
Big update....vector interpolation support

### DIFF
--- a/src/interpolate.f90
+++ b/src/interpolate.f90
@@ -1,7 +1,5 @@
-subroutine interpolate(ip,ipopt,igdtnumi,igdtmpli,igdtleni, &
-                       igdtnumo,igdtmplo,igdtleno, &
-                       mi,mo,km,ibi,li,gi, &
-                       no,ibo,lo,go,rlat,rlon,iret)
+subroutine interpolate_scalar(ip,ipopt,igdtnumi,igdtmpli,igdtleni,igdtnumo,igdtmplo,&
+                              igdtleno,mi,mo,km,ibi,li,gi,no,ibo,lo,go,rlat,rlon,iret)
 use ipolates_mod
 implicit none
 
@@ -44,4 +42,57 @@ call ipolates_grib2(ip,ipopt,igdtnumi,igdtmpli,igdtleni,igdtnumo,igdtmplo,igdtle
                     mi,mo,km,ibi,li,gi,no,rlat,rlon,ibo,lo,go,iret)
 
 return
-end subroutine interpolate
+end subroutine interpolate_scalar
+! ---------------------------------------------------------------------------------------- 
+! ---------------------------------------------------------------------------------------- 
+! ---------------------------------------------------------------------------------------- 
+subroutine interpolate_vector(ip,ipopt,igdtnumi,igdtmpli,igdtleni,igdtnumo,igdtmplo,&
+                              igdtleno,mi,mo,km,ibi,li,ui,vi,no,ibo,lo,uo,vo,rlat,rlon,&
+                              crot,srot,iret)
+use ipolatev_mod
+implicit none
+
+! ---------------------------------------------------------------------------------------- 
+! Input/Output Variables
+! ---------------------------------------------------------------------------------------- 
+integer, intent(in) :: ip
+integer, intent(in), dimension(20) :: ipopt
+integer, intent(in) :: igdtnumi
+integer, intent(in), dimension(igdtleni) :: igdtmpli
+integer, intent(in) :: igdtleni
+integer, intent(in) :: igdtnumo
+integer, intent(in), dimension(igdtleno) :: igdtmplo
+integer, intent(in) :: igdtleno
+integer, intent(in) :: mi
+integer, intent(in) :: mo
+integer, intent(in) :: km
+integer, intent(in), dimension(km) :: ibi
+logical(kind=1), intent(in), dimension(mi,km) :: li
+real, intent(in), dimension(mi,km) :: ui
+real, intent(in), dimension(mi,km) :: vi
+integer, intent(out) :: no
+integer, intent(out), dimension(km) :: ibo
+logical(kind=1), intent(out), dimension(mo,km) :: lo
+real, intent(out), dimension(mo,km) :: uo
+real, intent(out), dimension(mo,km) :: vo
+real, intent(inout), dimension(mo) :: rlat
+real, intent(inout), dimension(mo) :: rlon
+real, intent(inout), dimension(mo) :: crot
+real, intent(inout), dimension(mo) :: srot
+integer, intent(out) :: iret
+
+! ---------------------------------------------------------------------------------------- 
+! Initialize
+! ---------------------------------------------------------------------------------------- 
+iret=0
+no=0
+
+! ---------------------------------------------------------------------------------------- 
+! Call NCEPLIBS-ip subroutine, ipolatev_grib2 to perform interpolation of vector fields
+! using GRIB2 metadata.
+! ---------------------------------------------------------------------------------------- 
+call ipolatev_grib2(ip,ipopt,igdtnumi,igdtmpli,igdtleni,igdtnumo,igdtmplo,igdtleno,&
+                    mi,mo,km,ibi,li,ui,vi,no,rlat,rlon,crot,srot,ibo,lo,uo,vo,iret)
+
+return
+end subroutine interpolate_vector

--- a/src/interpolate.pyf
+++ b/src/interpolate.pyf
@@ -3,7 +3,7 @@
 
 python module interpolate ! in 
     interface  ! in :interpolate
-        subroutine interpolate(ip,ipopt,igdtnumi,igdtmpli,igdtleni,igdtnumo,igdtmplo,igdtleno,mi,mo,km,ibi,li,gi,no,ibo,lo,go,rlat,rlon,iret) ! in :interpolate:interpolate.f90
+        subroutine interpolate_scalar(ip,ipopt,igdtnumi,igdtmpli,igdtleni,igdtnumo,igdtmplo,igdtleno,mi,mo,km,ibi,li,gi,no,ibo,lo,go,rlat,rlon,iret) ! in :interpolate:interpolate.f90
             threadsafe
             use ipolates_mod
             integer intent(in) :: ip
@@ -27,7 +27,36 @@ python module interpolate ! in
             real dimension(mo),intent(inout),depend(mo) :: rlat
             real dimension(mo),intent(inout),depend(mo) :: rlon
             integer intent(out) :: iret
-        end subroutine interpolate
+        end subroutine interpolate_scalar
+        subroutine interpolate_vector(ip,ipopt,igdtnumi,igdtmpli,igdtleni,igdtnumo,igdtmplo,igdtleno,mi,mo,km,ibi,li,ui,vi,no,ibo,lo,uo,vo,rlat,rlon,crot,srot,iret) ! in :interpolate:interpolate.f90
+            threadsafe
+            use ipolatev_mod
+            integer intent(in) :: ip
+            integer dimension(20),intent(in) :: ipopt
+            integer intent(in) :: igdtnumi
+            integer dimension(igdtleni),intent(in) :: igdtmpli
+            integer, optional,intent(in),check(shape(igdtmpli, 0) == igdtleni),depend(igdtmpli) :: igdtleni=shape(igdtmpli, 0)
+            integer intent(in) :: igdtnumo
+            integer dimension(igdtleno),intent(in) :: igdtmplo
+            integer, optional,intent(in),check(shape(igdtmplo, 0) == igdtleno),depend(igdtmplo) :: igdtleno=shape(igdtmplo, 0)
+            integer, optional,intent(in),check(shape(li, 0) == mi),depend(li) :: mi=shape(li, 0)
+            integer, optional,intent(in),check(shape(uo, 0) == mo),depend(uo) :: mo=shape(uo, 0)
+            integer, optional,intent(in),check(shape(ibi, 0) == km),depend(ibi) :: km=shape(ibi, 0)
+            integer dimension(km),intent(in) :: ibi
+            logical(kind=1) dimension(mi,km),intent(in),depend(km) :: li
+            real dimension(mi,km),intent(in),depend(km,mi) :: ui
+            real dimension(mi,km),intent(in),depend(km,mi) :: vi
+            integer intent(out) :: no
+            integer dimension(km),intent(out),depend(km) :: ibo
+            logical(kind=1) dimension(mo,km),intent(out),depend(mo,km) :: lo
+            real dimension(mo,km),intent(inout),depend(mo,km) :: uo
+            real dimension(mo,km),intent(inout),depend(mo,km) :: vo
+            real dimension(mo),intent(inout),depend(mo) :: rlat
+            real dimension(mo),intent(inout),depend(mo) :: rlon
+            real dimension(mo),intent(inout),depend(mo) :: crot
+            real dimension(mo),intent(inout),depend(mo) :: srot
+            integer intent(out) :: iret
+        end subroutine interpolate_vector
     end interface 
 end python module interpolate
 

--- a/tests/test_grib2_interp_to_grid.py
+++ b/tests/test_grib2_interp_to_grid.py
@@ -8,9 +8,12 @@ gdtn_nbm = 30
 gdt_nbm = [1, 0, 6371200, 255, 255, 255, 255, 1173, 799, 19229000, 233723400,
            48, 25000000, 265000000, 5079406, 5079406, 0, 64, 25000000,
            25000000, -90000000, 0]
+
 nbm_grid_def = grib2io.Grib2GridDef(gdtn_nbm, gdt_nbm)
 nx = gdt_nbm[7]
 ny = gdt_nbm[8]
+
+rtol = 1e-04
 
 def _writer(path,a):
     """
@@ -29,7 +32,7 @@ def test_bicubic_interp_to_grid(request):
         #_writer(outputdata / filename,newmsg.data)
         x = newmsg.data
         y = np.fromfile(outputdata / filename,dtype=np.float32).reshape(ny,nx)
-        np.testing.assert_allclose(x,y,rtol=1e-02,atol=1e-02)
+        np.testing.assert_allclose(x,y,rtol=rtol)
 
 def test_bilinear_interp_to_grid(request):
     data = request.config.rootdir / 'tests' / 'input_data'
@@ -41,7 +44,7 @@ def test_bilinear_interp_to_grid(request):
         #_writer(outputdata / filename,newmsg.data)
         x = newmsg.data
         y = np.fromfile(outputdata / filename,dtype=np.float32).reshape(ny,nx)
-        np.testing.assert_allclose(x,y,rtol=1e-02,atol=1e-02)
+        np.testing.assert_allclose(x,y,rtol=rtol)
 
 def test_budget_interp_to_grid(request):
     data = request.config.rootdir / 'tests' / 'input_data'
@@ -52,7 +55,7 @@ def test_budget_interp_to_grid(request):
         newmsg = msg.interpolate('budget',nbm_grid_def)
         x = newmsg.data
         y = np.fromfile(outputdata / filename,dtype=np.float32).reshape(ny,nx)
-        np.testing.assert_allclose(x,y,rtol=1e-02,atol=1e-02)
+        np.testing.assert_allclose(x,y,rtol=rtol)
 
 def test_neighbor_interp_to_grid(request):
     data = request.config.rootdir / 'tests' / 'input_data'
@@ -64,7 +67,7 @@ def test_neighbor_interp_to_grid(request):
         #_writer(outputdata / filename,newmsg.data)
         x = newmsg.data
         y = np.fromfile(outputdata / filename,dtype=np.float32).reshape(ny,nx)
-        np.testing.assert_allclose(x,y,rtol=1e-02,atol=1e-02)
+        np.testing.assert_allclose(x,y,rtol=rtol)
 
 def test_neighbor_budget_interp_to_grid(request):
     data = request.config.rootdir / 'tests' / 'input_data'
@@ -76,4 +79,4 @@ def test_neighbor_budget_interp_to_grid(request):
         #_writer(outputdata / filename,newmsg.data)
         x = newmsg.data
         y = np.fromfile(outputdata / filename,dtype=np.float32).reshape(ny,nx)
-        np.testing.assert_allclose(x,y,rtol=1e-02,atol=1e-02)
+        np.testing.assert_allclose(x,y,rtol=rtol)

--- a/tests/test_grib2_interp_to_stations_scalar.py
+++ b/tests/test_grib2_interp_to_stations_scalar.py
@@ -8,42 +8,46 @@ import grib2io
 lats = [  39.8605,  40.4846,  25.7542,  41.9602,  39.8466,  37.6196]
 lons = [ -75.2708, -80.2145, -80.3839, -87.9316,-104.6562,-122.3656]
 
+grid_def_out = grib2io.Grib2GridDef(-1,lats=lats,lons=lons)
+
+rtol = 1e-05
+
 def test_bicubic_interp_to_stations(request):
     data = request.config.rootdir / 'tests' / 'input_data'
     with grib2io.open(data / 'gfs.t00z.pgrb2.1p00.f024') as f:
         msg = f.select(shortName='TMP',level='2 m above ground')[0]
         grid_def_in = grib2io.Grib2GridDef(msg.gdtn,msg.gridDefinitionTemplate)
-        sdata = grib2io.interpolate_to_stations(msg.data,'bicubic',grid_def_in,lats=lats,lons=lons)
-        np.testing.assert_allclose(sdata,np.array([290.51328, 280.273, 299.15262, 281.8346, 283.5935, 285.205]))
+        sdata = grib2io.interpolate(msg.data,'bicubic',grid_def_in,grid_def_out)
+        np.testing.assert_allclose(sdata,np.array([290.51328, 280.273, 299.15262, 281.8346, 283.5935, 285.205]),rtol=rtol)
 
 def test_bilinear_interp_to_stations(request):
     data = request.config.rootdir / 'tests' / 'input_data'
     with grib2io.open(data / 'gfs.t00z.pgrb2.1p00.f024') as f:
         msg = f.select(shortName='TMP',level='2 m above ground')[0]
         grid_def_in = grib2io.Grib2GridDef(msg.gdtn,msg.gridDefinitionTemplate)
-        sdata = grib2io.interpolate_to_stations(msg.data,'bilinear',grid_def_in,lats=lats,lons=lons)
-        np.testing.assert_allclose(sdata,np.array([290.19937, 280.47717, 299.17844, 281.69833, 283.07642, 285.1446]))
+        sdata = grib2io.interpolate(msg.data,'bilinear',grid_def_in,grid_def_out)
+        np.testing.assert_allclose(sdata,np.array([290.19937, 280.47717, 299.17844, 281.69833, 283.07642, 285.1446]),rtol=rtol)
 
 def test_budget_interp_to_stations(request):
     data = request.config.rootdir / 'tests' / 'input_data'
     with grib2io.open(data / 'gfs.t00z.pgrb2.1p00.f024') as f:
         msg = f.select(shortName='TMP',level='2 m above ground')[0]
         grid_def_in = grib2io.Grib2GridDef(msg.gdtn,msg.gridDefinitionTemplate)
-        sdata = grib2io.interpolate_to_stations(msg.data,'budget',grid_def_in,lats=lats,lons=lons)
-        np.testing.assert_allclose(sdata,np.array([289.66833, 280.4579, 299.18106, 280.9805, 282.58932, 285.13675]))
+        sdata = grib2io.interpolate(msg.data,'budget',grid_def_in,grid_def_out)
+        np.testing.assert_allclose(sdata,np.array([289.66833, 280.4579, 299.18106, 280.9805, 282.58932, 285.13675]),rtol=rtol)
 
 def test_neighbor_interp_to_stations(request):
     data = request.config.rootdir / 'tests' / 'input_data'
     with grib2io.open(data / 'gfs.t00z.pgrb2.1p00.f024') as f:
         msg = f.select(shortName='TMP',level='2 m above ground')[0]
         grid_def_in = grib2io.Grib2GridDef(msg.gdtn,msg.gridDefinitionTemplate)
-        sdata = grib2io.interpolate_to_stations(msg.data,'neighbor',grid_def_in,lats=lats,lons=lons)
-        np.testing.assert_allclose(sdata,np.array([291.9625, 282.1125, 299.7225, 281.8125, 282.1825, 285.3825]))
+        sdata = grib2io.interpolate(msg.data,'neighbor',grid_def_in,grid_def_out)
+        np.testing.assert_allclose(sdata,np.array([291.9625, 282.1125, 299.7225, 281.8125, 282.1825, 285.3825]),rtol=rtol)
 
 def test_neighbor_budget_interp_to_stations(request):
     data = request.config.rootdir / 'tests' / 'input_data'
     with grib2io.open(data / 'gfs.t00z.pgrb2.1p00.f024') as f:
         msg = f.select(shortName='TMP',level='2 m above ground')[0]
         grid_def_in = grib2io.Grib2GridDef(msg.gdtn,msg.gridDefinitionTemplate)
-        sdata = grib2io.interpolate_to_stations(msg.data,'neighbor-budget',grid_def_in,lats=lats,lons=lons)
-        np.testing.assert_allclose(sdata,np.array([290.60046, 280.74164, 299.11053, 281.8125, 283.12054, 285.14172]))
+        sdata = grib2io.interpolate(msg.data,'neighbor-budget',grid_def_in,grid_def_out)
+        np.testing.assert_allclose(sdata,np.array([290.60046, 280.74164, 299.11053, 281.8125, 283.12054, 285.14172]),rtol=rtol)

--- a/tests/test_grib2_interp_to_stations_vector.py
+++ b/tests/test_grib2_interp_to_stations_vector.py
@@ -1,0 +1,65 @@
+import pytest
+import numpy as np
+import datetime
+import grib2io
+
+np.set_printoptions(formatter={'float': '{: 0.5f}'.format})
+
+# Test stations
+#            KPHL,     KPIT,     KMFL,     KORD,     KDEN,     KSFO
+lats = [  39.8605,  40.4846,  25.7542,  41.9602,  39.8466,  37.6196]
+lons = [ -75.2708, -80.2145, -80.3839, -87.9316,-104.6562,-122.3656]
+
+grid_def_out = grib2io.Grib2GridDef(-1,lats=lats,lons=lons)
+
+rtol = 1e-05
+
+def test_bicubic_interp_to_stations(request):
+    data = request.config.rootdir / 'tests' / 'input_data'
+    with grib2io.open(data / 'gfs.t00z.pgrb2.1p00.f024') as f:
+        umsg = f.select(shortName='UGRD',level='10 m above ground')[0]
+        vmsg = f.select(shortName='VGRD',level='10 m above ground')[0]
+        grid_def_in = grib2io.Grib2GridDef(umsg.gdtn,umsg.gridDefinitionTemplate)
+        sdata = grib2io.interpolate((umsg.data,vmsg.data),'bicubic',grid_def_in,grid_def_out)
+        np.testing.assert_allclose(sdata[0],np.array([2.77504, 1.13036, -5.58242, -2.72262, 1.35933, 4.20723]),rtol=rtol)
+        np.testing.assert_allclose(sdata[1],np.array([-2.8205, -2.5066, -8.25053, -2.28479, 1.5556, 3.09094]),rtol=rtol)
+
+def test_bilinear_interp_to_stations(request):
+    data = request.config.rootdir / 'tests' / 'input_data'
+    with grib2io.open(data / 'gfs.t00z.pgrb2.1p00.f024') as f:
+        umsg = f.select(shortName='UGRD',level='10 m above ground')[0]
+        vmsg = f.select(shortName='VGRD',level='10 m above ground')[0]
+        grid_def_in = grib2io.Grib2GridDef(umsg.gdtn,umsg.gridDefinitionTemplate)
+        sdata = grib2io.interpolate((umsg.data,vmsg.data),'bilinear',grid_def_in,grid_def_out)
+        np.testing.assert_allclose(sdata[0],np.array([2.67897, 1.09885, -5.73067, -2.66697, 0.93868, 3.85792]),rtol=rtol)
+        np.testing.assert_allclose(sdata[1],np.array([-3.00674, -2.67472, -8.32837, -2.31592, 2.11204, 2.90466]),rtol=rtol)
+
+def test_budget_interp_to_stations(request):
+    data = request.config.rootdir / 'tests' / 'input_data'
+    with grib2io.open(data / 'gfs.t00z.pgrb2.1p00.f024') as f:
+        umsg = f.select(shortName='UGRD',level='10 m above ground')[0]
+        vmsg = f.select(shortName='VGRD',level='10 m above ground')[0]
+        grid_def_in = grib2io.Grib2GridDef(umsg.gdtn,umsg.gridDefinitionTemplate)
+        sdata = grib2io.interpolate((umsg.data,vmsg.data),'budget',grid_def_in,grid_def_out)
+        np.testing.assert_allclose(sdata[0],np.array([2.60448, 1.11867, -5.74128, -2.65074, 0.61570, 3.84874]),rtol=rtol)
+        np.testing.assert_allclose(sdata[1],np.array([-3.19010, -2.74230, -8.34333, -2.86165, 2.39821, 2.87611]),rtol=rtol)
+
+def test_neighbor_interp_to_stations(request):
+    data = request.config.rootdir / 'tests' / 'input_data'
+    with grib2io.open(data / 'gfs.t00z.pgrb2.1p00.f024') as f:
+        umsg = f.select(shortName='UGRD',level='10 m above ground')[0]
+        vmsg = f.select(shortName='VGRD',level='10 m above ground')[0]
+        grid_def_in = grib2io.Grib2GridDef(umsg.gdtn,umsg.gridDefinitionTemplate)
+        sdata = grib2io.interpolate((umsg.data,vmsg.data),'neighbor',grid_def_in,grid_def_out)
+        np.testing.assert_allclose(sdata[0],np.array([2.88667, 1.40519, -7.25290, -2.59283, 2.89911, 3.11281]),rtol=rtol)
+        np.testing.assert_allclose(sdata[1],np.array([-2.60096, -2.65632, -9.70096, -1.98764, -2.51089, 4.08250]),rtol=rtol)
+
+def test_neighbor_budget_interp_to_stations(request):
+    data = request.config.rootdir / 'tests' / 'input_data'
+    with grib2io.open(data / 'gfs.t00z.pgrb2.1p00.f024') as f:
+        umsg = f.select(shortName='UGRD',level='10 m above ground')[0]
+        vmsg = f.select(shortName='VGRD',level='10 m above ground')[0]
+        grid_def_in = grib2io.Grib2GridDef(umsg.gdtn,umsg.gridDefinitionTemplate)
+        sdata = grib2io.interpolate((umsg.data,vmsg.data),'neighbor-budget',grid_def_in,grid_def_out)
+        np.testing.assert_allclose(sdata[0],np.array([2.73996, 1.11899, -5.61142, -2.59283, 0.61475, 3.95788]),rtol=rtol)
+        np.testing.assert_allclose(sdata[1],np.array([-3.11859, -2.70217, -8.24905, -1.98764, 2.78802, 2.81118]),rtol=rtol)


### PR DESCRIPTION
In interpolate.f90, added new subroutine interpolate_vector that serves as a wrapper for NCEPLIBS-ip ipolatev_grib2.

In interpolate.pyf, added f2py subroutine interface for interpolate_vector.

Updated tests and added new tests for vector interpolation.