### PR TITLE
Clean up of setup.py

### DIFF
--- a/.github/workflows/build_macosx.yml
+++ b/.github/workflows/build_macosx.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4	
 
     - name: Set up Python (Conda)
-    - uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         channels: conda-forge

--- a/.github/workflows/build_macosx.yml
+++ b/.github/workflows/build_macosx.yml
@@ -38,5 +38,5 @@ jobs:
 
     - name: Test with pytest
       run: |
-	env
+        python --version
         #pytest

--- a/.github/workflows/build_macosx.yml
+++ b/.github/workflows/build_macosx.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v4	
@@ -30,7 +30,7 @@ jobs:
 
     - name: Install conda dependencies
       run: |
-        conda install c-compiler gfortran nceplibs-ip ninja numpy pip pytest setuptools
+        conda install c-compiler gfortran nceplibs-g2c nceplibs-ip ninja numpy pip pytest setuptools
 
     - name: Install with pip
       run: |

--- a/.github/workflows/build_macosx.yml
+++ b/.github/workflows/build_macosx.yml
@@ -17,24 +17,26 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
+    - uses: actions/checkout@v4	
+
+    - name: Set up Python (Conda)
     - uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         channels: conda-forge
         python-version: ${{ matrix.python-version }}
+        auto-active-base: true
+        activate-environment: test
 
-    - name: Install dependencies
+    - name: Install conda dependencies
       run: |
-        conda install c-compiler gfortran nceplibs-ip ninja numpy pip setuptools
+        conda install c-compiler gfortran nceplibs-ip ninja numpy pip pytest setuptools
+
     - name: Install with pip
       run: |
         pip install .
+
     - name: Test with pytest
       run: |
-        conda install pytest
+	env
         #pytest

--- a/.github/workflows/build_macosx.yml
+++ b/.github/workflows/build_macosx.yml
@@ -25,7 +25,7 @@ jobs:
         auto-update-conda: true
         channels: conda-forge
         python-version: ${{ matrix.python-version }}
-        auto-active-base: true
+        auto-activate-base: true
         activate-environment: test
 
     - name: Install conda dependencies

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -8,33 +8,31 @@ jobs:
     name: Python (${{ matrix.python-version }})
     runs-on: windows-latest
 
-    defaults:
-      run:
-        shell: bash -el {0}
-
     strategy:
       matrix:
         python-version: ["3.8","3.9","3.10","3.11"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/checkout@v4
+
+    - name: Set up Python (Conda)
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         channels: conda-forge
         python-version: ${{ matrix.python-version }}
+        auto-activate-base: true
+        activate-environment: test
 
-    - name: Install dependencies
+    - name: Install conda dependencies
       run: |
-        conda install c-compiler m2w64-gcc-fortran m2w64-gcc-libs nceplibs-ip ninja numpy pip setuptools
+        conda install c-compiler m2w64-gcc-fortran m2w64-gcc-libs nceplibs-g2c nceplibs-ip ninja numpy pip setuptools
+
     - name: Install with pip
       run: |
         pip install .
+
     - name: Test with pytest
       run: |
-        conda install pytest
+        python --version
         #pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
   "Operating System :: MacOS",
 ]
 dependencies = [
-  "numpy",
+  "numpy<2.0.0",
   "grib2io"
 ] 
 dynamic = ["version"]

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def find_library(name, dirs=None, static=False):
     libext = ".a" if static else libext
     if dirs is None:
         print(os.environ["CONDA_PREFIX"])
-        if 'CONDA_PREFIX' in os.environ["CONDA_PREFIX"]:
+        if 'CONDA_PREFIX' in os.environ:
             dirs = [os.environ["CONDA_PREFIX"]]
             if sys.platform == "darwin":
                 libext = ".so" # If in conda and macos, then use ".so"

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,10 @@ def find_library(name, dirs=None, static=False):
         else:
             out.append(ctypes_find_library(name))
 
+    stuff = out.append(ctypes_find_library(name))
+    print(f'{stuff = }')
+    print(f'{out = }')
+
     # For Linux and macOS (Apple Silicon), we have to search ourselves.
     libext = _libext_by_platform[sys.platform]
     libext = ".a" if static else libext

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ def find_library(name, dirs=None, static=False):
     #
     # IMPORTANT: The following does not work at this time (Jan. 2024) for macOS on
     # Apple Silicon.
+    print(os.name, sys.platform)
     if (os.name, sys.platform) != ("posix", "linux"):
         if (sys.platform, platform.machine()) == ("darwin", "arm64"):
             pass
@@ -32,7 +33,8 @@ def find_library(name, dirs=None, static=False):
     libext = _libext_by_platform[sys.platform]
     libext = ".a" if static else libext
     if dirs is None:
-        if os.environ.get("CONDA_PREFIX"):
+        print(os.environ["CONDA_PREFIX"])
+        if 'CONDA_PREFIX' in os.environ["CONDA_PREFIX"]:
             dirs = [os.environ["CONDA_PREFIX"]]
             if sys.platform == "darwin":
                 libext = ".so" # If in conda and macos, then use ".so"

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,10 @@ def find_library(name, dirs=None, static=False):
     libext = _libext_by_platform[sys.platform]
     libext = ".a" if static else libext
     if dirs is None:
-        print(os.environ["CONDA_PREFIX"])
         if 'CONDA_PREFIX' in os.environ:
             dirs = [os.environ["CONDA_PREFIX"]]
-            if sys.platform == "darwin":
-                libext = ".so" # If in conda and macos, then use ".so"
+            #if sys.platform == "darwin":
+            #    libext = ".so" # If in conda and macos, then use ".so"
         else:
             dirs = ["/usr/local", "/sw", "/opt", "/opt/local", "/opt/homebrew", "/usr"]
     if os.environ.get("LD_LIBRARY_PATH"):

--- a/setup.py
+++ b/setup.py
@@ -22,16 +22,16 @@ def find_library(name, dirs=None, static=False):
     #
     # IMPORTANT: The following does not work at this time (Jan. 2024) for macOS on
     # Apple Silicon.
+    print(f'{out = }')
     print(os.name, sys.platform)
     print(sys.platform, platform.machine())
     if (os.name, sys.platform) != ("posix", "linux"):
-        if (sys.platform, platform.machine()) == ("darwin", "arm64"):
-            pass
-        else:
-            out.append(ctypes_find_library(name))
+        out.append(ctypes_find_library(name))
+        #if (sys.platform, platform.machine()) == ("darwin", "arm64"):
+        #    pass
+        #else:
+        #    out.append(ctypes_find_library(name))
 
-    stuff = out.append(ctypes_find_library(name))
-    print(f'{stuff = }')
     print(f'{out = }')
 
     # For Linux and macOS (Apple Silicon), we have to search ourselves.

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ def find_library(name, dirs=None, static=False):
     # IMPORTANT: The following does not work at this time (Jan. 2024) for macOS on
     # Apple Silicon.
     print(os.name, sys.platform)
+    print(sys.platform, platform.machine())
     if (os.name, sys.platform) != ("posix", "linux"):
         if (sys.platform, platform.machine()) == ("darwin", "arm64"):
             pass

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@ import platform
 import subprocess
 import sys
 
-def get_grib2io_version():
+def get_version():
     with open("VERSION","rt") as f:
         ver = f.readline().strip()
     return ver
 
 def find_library(name, dirs=None, static=False):
-    _libext_by_platform = {"linux": ".so", "darwin": ".dylib"}
+    _libext_by_platform = {"linux": ".so", "darwin": ".dylib", "win32": ".dll"}
     out = []
 
     # According to the ctypes documentation Mac and Windows ctypes_find_library
@@ -34,6 +34,8 @@ def find_library(name, dirs=None, static=False):
     if dirs is None:
         if os.environ.get("CONDA_PREFIX"):
             dirs = [os.environ["CONDA_PREFIX"]]
+            if sys.platform == "darwin":
+                libext = ".so" # If in conda and macos, then use ".so"
         else:
             dirs = ["/usr/local", "/sw", "/opt", "/opt/local", "/opt/homebrew", "/usr"]
     if os.environ.get("LD_LIBRARY_PATH"):
@@ -56,12 +58,12 @@ directories:
 # ----------------------------------------------------------------------------------------
 # Main part of script
 # ----------------------------------------------------------------------------------------
-VERSION = get_grib2io_version()
+VERSION = get_version()
 
 needs_sp = False
 needs_openmp = False
 openmp_libname = ''
-usestaticlibs = False
+use_static_libs = False
 libraries = ['ip_4']
 
 incdirs = []
@@ -83,15 +85,15 @@ if os.environ.get('USE_STATIC_LIBS'):
     val = os.environ.get('USE_STATIC_LIBS')
     if val not in {'True','False'}:
         raise ValueError('Environment variable USE_STATIC_LIBS must be \'True\' or \'False\'')
-    usestaticlibs = True if val == 'True' else False
-usestaticlibs = config.get('options', 'use_static_libs', fallback=usestaticlibs)
+    use_static_libs = True if val == 'True' else False
+use_static_libs = config.get('options', 'use_static_libs', fallback=use_static_libs)
 
 # ----------------------------------------------------------------------------------------
 # Get NCEPLIBS-ip library info.
 # ----------------------------------------------------------------------------------------
 if os.environ.get('IP_DIR'):
     ip_dir = os.environ.get('IP_DIR')
-    ip_libdir = os.path.dirname(find_library('ip_4', dirs=[ip_dir], static=usestaticlibs))
+    ip_libdir = os.path.dirname(find_library('ip_4', dirs=[ip_dir], static=use_static_libs))
     ip_incdir = os.path.join(ip_dir,'include_4')
 else:
     ip_dir = config.get('directories','ip_dir',fallback=None)
@@ -107,8 +109,8 @@ incdirs.append(ip_incdir)
 # ----------------------------------------------------------------------------------------
 # Check for if sp and OpenMP library objects are in the ip library
 # ----------------------------------------------------------------------------------------
-ip_staticlib = find_library('ip_4', dirs=libdirs, static=usestaticlibs)
-if usestaticlibs:
+ip_staticlib = find_library('ip_4', dirs=libdirs, static=use_static_libs)
+if use_static_libs:
     extra_objects.append(ip_staticlib)
     # Check for sp
     cmd = subprocess.run(['ar','-t',ip_staticlib], stdout=subprocess.PIPE)
@@ -126,7 +128,7 @@ if usestaticlibs:
         needs_openmp = True
         openmp_libname = 'iomp5'
 else:
-    iplib = find_library('ip_4', dirs=libdirs, static=usestaticlibs)
+    iplib = find_library('ip_4', dirs=libdirs, static=use_static_libs)
     # Check for sp
     if sys.platform == 'darwin':
         cmd = subprocess.run(['otool','-L',iplib], stdout=subprocess.PIPE)
@@ -158,23 +160,23 @@ else:
 if needs_sp:
     if os.environ.get('SP_DIR'):
         sp_dir = os.environ.get('SP_DIR')
-        sp_libdir = os.path.dirname(find_library('sp_4', dirs=[sp_dir], static=usestaticlibs))
+        sp_libdir = os.path.dirname(find_library('sp_4', dirs=[sp_dir], static=use_static_libs))
     else:
         sp_dir = config.get('directories','sp_dir',fallback=None)
         if sp_dir is None:
-            sp_libdir = os.path.dirname(find_library('sp_4', static=usestaticlibs))
+            sp_libdir = os.path.dirname(find_library('sp_4', static=use_static_libs))
         else:
-            sp_libdir = os.path.dirname(find_library('sp_4', dirs=[sp_dir], static=usestaticlibs))
+            sp_libdir = os.path.dirname(find_library('sp_4', dirs=[sp_dir], static=use_static_libs))
     libdirs.append(sp_libdir)
-    if usestaticlibs:
-        extra_objects.append(find_library('sp_4', dirs=[sp_libdir], static=usestaticlibs))
+    if use_static_libs:
+        extra_objects.append(find_library('sp_4', dirs=[sp_libdir], static=use_static_libs))
     libraries.append('sp_4')
 
-libraries = [] if usestaticlibs else list(set(libraries))
+libraries = [] if use_static_libs else list(set(libraries))
 incdirs = list(set(incdirs))
 incdirs.append(numpy.get_include())
-libdirs = [] if usestaticlibs else list(set(libdirs))
-extra_objects = list(set(extra_objects)) if usestaticlibs else []
+libdirs = [] if use_static_libs else list(set(libdirs))
+extra_objects = list(set(extra_objects)) if use_static_libs else []
 
 # ----------------------------------------------------------------------------------------
 # Get OpenMP library info if needed. Regardless of static or dynamic linking to
@@ -187,7 +189,7 @@ extra_objects = list(set(extra_objects)) if usestaticlibs else []
 if needs_openmp:
     libraries.append(openmp_libname)
 
-print(f'Use static libs: {usestaticlibs}')
+print(f'Use static libs: {use_static_libs}')
 print(f'Needs OpenMP: {needs_openmp}')
 print(f'Needs NCEPLIBS-sp: {needs_sp}')
 print(f'\t{libraries = }')

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,13 @@ import subprocess
 import sys
 
 def get_version():
+    """Get version string"""
     with open("VERSION","rt") as f:
         ver = f.readline().strip()
     return ver
 
 def find_library(name, dirs=None, static=False):
+    """Find library"""
     _libext_by_platform = {"linux": ".so", "darwin": ".dylib", "win32": ".dll"}
     out = []
 
@@ -48,12 +50,14 @@ directories:
     return out[0].absolute().resolve().as_posix()
 
 def run_ar_command(filename):
+    """Run the ar command"""
     cmd = subprocess.run(['ar','-t',filename],
                          stdout=subprocess.PIPE)
     cmdout = cmd.stdout.decode('utf-8')
     return cmdout
 
 def run_nm_command(filename):
+    """Run the nm command"""
     cmd = subprocess.run(['nm','-C',filename],
                          stdout=subprocess.PIPE,
                          stderr=subprocess.DEVNULL)
@@ -61,18 +65,21 @@ def run_nm_command(filename):
     return cmdout
 
 def run_ldd_command(filename):
+    """Run the ldd command"""
     cmd = subprocess.run(['ldd',filename],
                          stdout=subprocess.PIPE)
     cmdout = cmd.stdout.decode('utf-8')
     return cmdout
 
 def run_otool_command(filename):
+    """Run the otool command"""
     cmd = subprocess.run(['otool','-L',filename],
                          stdout=subprocess.PIPE)
     cmdout = cmd.stdout.decode('utf-8')
     return cmdout
 
 def check_for_openmp(ip_lib, static_lib=False):
+    """Check for OpenMP"""
     check = False
     info = ""
     libname = ""
@@ -102,6 +109,7 @@ def check_for_openmp(ip_lib, static_lib=False):
     return check, libname
 
 def check_for_sp(ip_lib, static_lib=False):
+    """Check for NCEPLIBS-sp"""
     check = False
     info = ""
     if static_lib:
@@ -117,7 +125,6 @@ def check_for_sp(ip_lib, static_lib=False):
         if 'libsp_4' in info: check=True
     return check 
          
-
 # ----------------------------------------------------------------------------------------
 # Main part of script
 # ----------------------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -19,20 +19,8 @@ def find_library(name, dirs=None, static=False):
 
     # According to the ctypes documentation Mac and Windows ctypes_find_library
     # returns the full path.
-    #
-    # IMPORTANT: The following does not work at this time (Jan. 2024) for macOS on
-    # Apple Silicon.
-    print(f'{out = }')
-    print(os.name, sys.platform)
-    print(sys.platform, platform.machine())
     if (os.name, sys.platform) != ("posix", "linux"):
         out.append(ctypes_find_library(name))
-        #if (sys.platform, platform.machine()) == ("darwin", "arm64"):
-        #    pass
-        #else:
-        #    out.append(ctypes_find_library(name))
-
-    print(f'{out = }')
 
     # For Linux and macOS (Apple Silicon), we have to search ourselves.
     libext = _libext_by_platform[sys.platform]
@@ -40,8 +28,6 @@ def find_library(name, dirs=None, static=False):
     if dirs is None:
         if 'CONDA_PREFIX' in os.environ:
             dirs = [os.environ["CONDA_PREFIX"]]
-            #if sys.platform == "darwin":
-            #    libext = ".so" # If in conda and macos, then use ".so"
         else:
             dirs = ["/usr/local", "/sw", "/opt", "/opt/local", "/opt/homebrew", "/usr"]
     if os.environ.get("LD_LIBRARY_PATH"):


### PR DESCRIPTION
A lot of testing done here to _**try**_ to get successful builds on Windows.  I think at this time, that is just not going to happen and probably will not happen until we migrate away from numpy distutils to meson.  There is just too much interplay between setuptools, numpy, f2py, etc and Windows.  The gfortran available from conda is outdated (version 5.3 from 2015).

But also done here was a reworking of setup.py to functionalize a lot of the logic for getting ip, sp (when needed), and openmp library information -- things that will make building on Windows easier down the road.